### PR TITLE
⬆️ chore: upgrade self-packaged dependencies (gstack, hapi)

### DIFF
--- a/packages/gstack/default.nix
+++ b/packages/gstack/default.nix
@@ -12,12 +12,12 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gstack";
-  version = "0-unstable-2026-04-17";
+  version = "0-unstable-2026-04-23";
   src = fetchFromGitHub {
     owner = "garrytan";
     repo = "gstack";
-    rev = "1211b6b40becb684eaf29b0f30a650a8a9b222a5";
-    hash = "sha256-0mVE49Bd7ORlZ4gEY5ovxY60ttWK72rGFPRLLdrd+O0=";
+    rev = "d75402bbd2513c55f62691347ec4c1f57c2c2830";
+    hash = "sha256-Klk0KB9n2flnn7mvjmYCTS1lDfgzhgowMCqxY9vV6Y0=";
   };
 
   # Fixed-output derivation for node_modules (network access allowed in sandbox)
@@ -53,8 +53,8 @@ stdenv.mkDerivation (finalAttrs: {
 
     outputHash =
       {
-        x86_64-linux = "sha256-S3Ls/ZjhcVILfgpzNjLA4JOfaFYCbBPbDJla1jh5Jf4=";
-        aarch64-darwin = "sha256-U4tG7eFBPILKtyPELWc7j0sgUXBq8U5AMNADBzcRi+M=";
+        x86_64-linux = lib.fakeSha256;
+        aarch64-darwin = lib.fakeSha256;
       }
       .${stdenv.hostPlatform.system}
         or (throw "gstack node_modules hash not available for ${stdenv.hostPlatform.system}");

--- a/packages/hapi/default.nix
+++ b/packages/hapi/default.nix
@@ -74,7 +74,7 @@ stdenv.mkDerivation (finalAttrs: {
     outputHash =
       {
         x86_64-linux = lib.fakeSha256;
-        aarch64-linux = lib.fakeSha256;
+        aarch64-linux = "sha256-LQxoam7I5kBWtnOo1a9W6zST2lkQ4aJA6D0l5Q90ZZs=";
         aarch64-darwin = lib.fakeSha256;
       }
       .${system} or (throw "hapi deps hash not available for ${system}");

--- a/packages/hapi/default.nix
+++ b/packages/hapi/default.nix
@@ -11,7 +11,7 @@
 }:
 
 let
-  version = "0.16.7";
+  version = "0.16.8";
 
   inherit (stdenv.hostPlatform) system;
   selectSystem = attrs: attrs.${system} or (throw "Unsupported system: ${system}");
@@ -34,7 +34,7 @@ let
     owner = "tiann";
     repo = "hapi";
     tag = "v${version}";
-    hash = "sha256-MzaC6ZCqfSgx+a+zEQWRa+Zb/7QZePucmpKgsi9BxIU=";
+    hash = "sha256-esU4mDiDR37SmtqucTeNSddb0I+49U8CLt/DyiHsB2A=";
   };
 in
 stdenv.mkDerivation (finalAttrs: {
@@ -73,9 +73,9 @@ stdenv.mkDerivation (finalAttrs: {
 
     outputHash =
       {
-        x86_64-linux = "sha256-06K0e/4r2LaYv2YcGWzUCPT/5iEs2eLcy1rMDj4QVN0=";
-        aarch64-linux = "sha256-FnlrKq+Ou89lktq3Ja5ai8lzFdxdz2s6BTklQTx0QfQ=";
-        aarch64-darwin = "sha256-S/u7IwWhlHqVdy50x5MZwU5EE1Wg5MNVLfNuhQHBXAQ=";
+        x86_64-linux = lib.fakeSha256;
+        aarch64-linux = lib.fakeSha256;
+        aarch64-darwin = lib.fakeSha256;
       }
       .${system} or (throw "hapi deps hash not available for ${system}");
     outputHashAlgo = "sha256";


### PR DESCRIPTION
## 📦 Self-Packaged Dependency Upgrades

Weekly automated check found **2 packages** with available updates:

### Updates

| Package | Type | Current | Latest |
|---------|------|---------|--------|
| **gstack** | commit-based | `0-unstable-2026-04-17` | `0-unstable-2026-04-23` |
| **hapi** | tag-based | `v0.16.7` | `v0.16.8` |

### Already Up-to-Date
- ✅ catppuccin-bat
- ✅ catppuccin-yazi-flavor
- ✅ pmp-library (3.0.0)
- ✅ pyzotero (v1.11.0)
- ✅ zotero-mcp (v0.3.0)

### ⚠️ Action Required: Deps Hashes
The `outputHash` for bun/node_modules deps have been set to `lib.fakeSha256` since they require platform-specific computation. **CI will fail** and report the correct hash values, which need to be filled in:

- **gstack**: `node_modules` outputHash (x86_64-linux, aarch64-darwin)
- **hapi**: deps outputHash (x86_64-linux, aarch64-linux, aarch64-darwin)

After CI runs, check the job logs for the correct `got:` hash values and update the PR.

### Not Checked (non-fetchFromGitHub)
- zai-mcp-server (fetchurl from npm registry)
- vaa3d-x (fetchurl from GitHub releases binary)
- with-secrets (no external fetch)