### PR TITLE
fix(homeManagerModules/hermes-agent): route documents to correct paths

### DIFF
--- a/home/ai/opencode.nix
+++ b/home/ai/opencode.nix
@@ -96,7 +96,8 @@ in
 
       mcp = {
         github = {
-          type = "http";
+          enabled = true;
+          type = "remote";
           url = "https://api.githubcopilot.com/mcp/";
           headers.Authorization = "Bearer {env:GITHUB_PAT}";
         };

--- a/homeManagerModules/hermes-agent/default.nix
+++ b/homeManagerModules/hermes-agent/default.nix
@@ -42,10 +42,14 @@ let
     + lib.concatStringsSep "\n" (
       lib.mapAttrsToList (
         name: value:
+        let
+          dir = dirOf name;
+          mkdir = lib.optionalString (dir != ".") "mkdir -p $out/${dir}";
+        in
         if builtins.isPath value || lib.isStorePath value then
-          "cp ${value} $out/${name}"
+          "${mkdir}\ncp ${value} $out/${name}"
         else
-          "cat > $out/${name} <<'HERMES_DOC_EOF'\n${value}\nHERMES_DOC_EOF"
+          "${mkdir}\ncat > $out/${name} <<'HERMES_DOC_EOF'\n${value}\nHERMES_DOC_EOF"
       ) cfg.documents
     )
   );
@@ -454,10 +458,16 @@ in
             HERMES_NIX_ENV_EOF
           ''}
 
-          # Link documents into workspace
+          # Link documents into correct locations
           ${lib.concatStringsSep "\n" (
-            lib.mapAttrsToList (name: _value: ''
-              install -m 0640 ${documentDerivation}/${name} ${cfg.workingDirectory}/${name}
+            lib.mapAttrsToList (name: _value: let
+              target = if name == "SOUL.md" then "${cfg.stateDir}/.hermes/SOUL.md"
+                else if lib.elem name ["USER.md" "MEMORY.md"] then "${cfg.stateDir}/.hermes/memories/${name}"
+                else "${cfg.workingDirectory}/${name}";
+              targetDir = dirOf target;
+            in ''
+              mkdir -p ${targetDir}
+              install -m 0640 ${documentDerivation}/${name} ${target}
             '') cfg.documents
           )}
         '';


### PR DESCRIPTION
## Summary

Fixes the home manager module's `documents` option to install files to the correct paths, matching where hermes-agent actually reads them. Mirrors the bug reported in NousResearch/hermes-agent#21341 for the upstream NixOS module.

### Problem

All `documents` entries were installed to `workingDirectory`, but hermes-agent reads:
- **SOUL.md** from `$HERMES_HOME/SOUL.md` (`agent/prompt_builder.py::load_soul_md()`)
- **USER.md / MEMORY.md** from `$HERMES_HOME/memories/` (`tools/memory_tool.py::MemoryStore.load_from_disk()`)

So personality and memory files placed via `documents` were silently ignored.

### Changes

1. **Activation script** — route files by name:
   - `SOUL.md` → `${stateDir}/.hermes/SOUL.md`
   - `USER.md` / `MEMORY.md` → `${stateDir}/.hermes/memories/`
   - Other files → `workingDirectory` (unchanged)

2. **`documentDerivation`** — support nested keys (e.g. `memories/USER.md`) by `mkdir -p` for subdirectory components.

### Testing

- `SOUL.md` will now be read by the agent on startup
- Non-personality documents (AGENTS.md, .cursorrules) continue to work as before