### PR TITLE
⬆️ update self-packaged dependencies (pyzotero 1.11.1)

### DIFF
--- a/packages/pyzotero/default.nix
+++ b/packages/pyzotero/default.nix
@@ -18,14 +18,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "pyzotero";
-  version = "1.11.0";
+  version = "1.11.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "urschrei";
     repo = "pyzotero";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-8K9Lg9Ehl0QARU2tAidMyynorPIMGtxDXzshmbpb6So=";
+    hash = "sha256-3pOdSoVSE3XhQ1Vy3/KiSGd3Yr+DBO4+wyfTtHEUTso=";
   };
 
   postPatch = ''


### PR DESCRIPTION
## Dependency Update Check (2025-05-15)

Automated check for updates to self-packaged `fetchFromGitHub` dependencies.

### ✅ Updated in this PR

| Package | Previous | New |
|---------|----------|-----|
| **pyzotero** | v1.11.0 | v1.11.1 |

### ℹ️ Updates available but require manual intervention

These packages have newer upstream versions but need complex hash updates (platform-specific fixed-output derivation hashes for node_modules/deps) that require `nix build` to compute:

| Package | Current | Latest |
|---------|---------|--------|
| **hapi** | v0.16.8 | v0.17.4 |
| **gstack** | `dc6252d` (2026-05-12) | `40e34de` (2026-05-14) |

### ✅ Already up to date (no changes needed)

| Package | Version/Commit |
|---------|----------------|
| gitmoji | v3.15.0 (latest) |
| catppuccin/starship | `5906cc3` (latest) |
| catppuccin/btop | `f437574` (latest) |
| catppuccin/delta | `74b47a3` (latest) |
| catppuccin/bat | `6810349` (latest) |
| catppuccin/yazi | `fc69d64` (latest) |
| anthropics/skills | `f458cee` (latest) |
| VoltAgent/awesome-claude-code-subagents | `6f804f0` (latest) |
| pmp-library | 3.0.0 (latest) |
| paseo-relay | v0.5.0 (latest) |
| zotero-mcp | v0.3.0 (latest) |
| btw.nvim | `47f6419` (latest) |
