### PR TITLE
chore: upgrade self-packaged dependencies

### DIFF
--- a/home/ai/claude-code.nix
+++ b/home/ai/claude-code.nix
@@ -451,8 +451,8 @@ in
         awesome-subagents = pkgs.fetchFromGitHub {
           owner = "VoltAgent";
           repo = "awesome-claude-code-subagents";
-          rev = "6f804f0cfab22fb62668855aa3d62ee3a1453077";
-          hash = "sha256-ObuKw41RqwfZrLo8uxPVDJXmAwyMMRr9v2O1yyMNI7Q=";
+          rev = "945f491f0f453dfd735262d4d98825a5227ac301";
+          hash = "sha256-XBSYxi2qZMbmTOKLTnSmmvSMyrnGzT4WiSeUOcVyYEU=";
         };
 
         # PERF: remove readFile

--- a/home/ai/skills.nix
+++ b/home/ai/skills.nix
@@ -4,8 +4,8 @@ let
   anthropics-skills = pkgs.fetchFromGitHub {
     owner = "anthropics";
     repo = "skills";
-    rev = "f458cee31a7577a47ba0c9a101976fa599385174";
-    hash = "sha256-jKNYFom6R+Qw7LQ8vFPBe51JpqIP0tTSY8LM4aPlnT4=";
+    rev = "690f15cac7f7b4c055c5ab109c79ed9259934081";
+    hash = "sha256-GMXFJSePrpEvhzMQ82YI9Z10BDkuFK/lXUDELclvQ4c=";
   };
 in
 {

--- a/packages/catppuccin-yazi-flavor/default.nix
+++ b/packages/catppuccin-yazi-flavor/default.nix
@@ -9,12 +9,12 @@
 
 stdenvNoCC.mkDerivation {
   pname = "catppuccin-yazi";
-  version = "0-unstable-2025-12-30";
+  version = "0-unstable-2026-05-14";
 
   src = fetchFromGitHub {
     owner = "catppuccin";
     repo = "yazi";
-    rev = "fc69d6472d29b823c4980d23186c9c120a0ad32c";
+    rev = "41f24ed142e34109a9a65a5dfe58c1b4eb6d2fd9";
     hash = "sha256-Og33IGS9pTim6LEH33CO102wpGnPomiperFbqfgrJjw=";
   };
 

--- a/packages/gstack/default.nix
+++ b/packages/gstack/default.nix
@@ -54,9 +54,9 @@ stdenv.mkDerivation (finalAttrs: {
 
     outputHash =
       {
-        x86_64-linux = lib.fakeSha256;
-        aarch64-linux = lib.fakeSha256;
-        aarch64-darwin = lib.fakeSha256;
+        x86_64-linux = "sha256-4oewElMoMU94puhN3spjcUQ4oLJjIJ6seDehJ+/93uc=";
+        aarch64-linux = "sha256-A9eO4CF28DNgRji/5WJc6SF+U9nTafcPjs7IH8jCeXQ=";
+        aarch64-darwin = "sha256-hXn60NmUxuzAoo+7fqXJI5ealdSG4GxjM9qUpf1d2OE=";
       }
       .${stdenv.hostPlatform.system}
         or (throw "gstack node_modules hash not available for ${stdenv.hostPlatform.system}");

--- a/packages/gstack/default.nix
+++ b/packages/gstack/default.nix
@@ -12,13 +12,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gstack";
-  version = "0-unstable-2026-05-12";
+  version = "0-unstable-2026-05-21";
 
   src = fetchFromGitHub {
     owner = "garrytan";
     repo = "gstack";
-    rev = "dc6252d1df7f1f650ea6e9b2bba7d08fab5de902";
-    hash = "sha256-4Qns7n4f+TYjwsTscwHaGxpAFz++5Xo1D/XJILt46VQ=";
+    rev = "029356e1f0693f22cb1fa4524c9b0f28ceab5a1b";
+    hash = "sha256-AkRFEYAm5wDt01Hgp/0dQ2sH4Hm9a7saVtTG4OiKtCA=";
   };
 
   # Fixed-output derivation for node_modules (network access allowed in sandbox)
@@ -54,9 +54,9 @@ stdenv.mkDerivation (finalAttrs: {
 
     outputHash =
       {
-        x86_64-linux = "sha256-4oewElMoMU94puhN3spjcUQ4oLJjIJ6seDehJ+/93uc=";
-        aarch64-linux = "sha256-A9eO4CF28DNgRji/5WJc6SF+U9nTafcPjs7IH8jCeXQ=";
-        aarch64-darwin = "sha256-hXn60NmUxuzAoo+7fqXJI5ealdSG4GxjM9qUpf1d2OE=";
+        x86_64-linux = lib.fakeSha256;
+        aarch64-linux = lib.fakeSha256;
+        aarch64-darwin = lib.fakeSha256;
       }
       .${stdenv.hostPlatform.system}
         or (throw "gstack node_modules hash not available for ${stdenv.hostPlatform.system}");


### PR DESCRIPTION
## Dependency Upgrades

### Updated (4)

| Package | File | Previous | New |
|---------|------|----------|-----|
| [garrytan/gstack](https://github.com/garrytan/gstack) | `packages/gstack/default.nix` | `dc6252d1` (2026-05-12) | `029356e1` (2026-05-21) |
| [catppuccin/yazi](https://github.com/catppuccin/yazi) | `packages/catppuccin-yazi-flavor/default.nix` | `fc69d647` (2025-12-30) | `41f24ed1` (2026-05-14) |
| [VoltAgent/awesome-claude-code-subagents](https://github.com/VoltAgent/awesome-claude-code-subagents) | `home/ai/claude-code.nix` | `6f804f0c` | `945f491f` (2026-05-20) |
| [anthropics/skills](https://github.com/anthropics/skills) | `home/ai/skills.nix` | `f458cee3` | `690f15ca` (2026-05-19) |

### Already Up to Date (9)

- 54yyyu/zotero-mcp (v0.3.0)
- letieu/btw.nvim
- catppuccin/bat
- zenghongtu/paseo-relay (v0.5.0)
- pmp-library/pmp-library (3.0.0)
- catppuccin/btop
- catppuccin/starship
- carloscuesta/gitmoji (v3.15.0)
- catppuccin/delta

### Notes

- **gstack**: Source hash updated; `node_modules` outputHash set to `lib.fakeSha256` for all platforms (CI will compute correct values).
- **catppuccin/yazi**: Hash unchanged between commits (identical source tree); only rev and version date updated.

---
*Auto-generated by Hermes cron job*