### PR TITLE
chore: upgrade self-packaged dependencies

### DIFF
--- a/packages/gstack/default.nix
+++ b/packages/gstack/default.nix
@@ -54,9 +54,9 @@ stdenv.mkDerivation (finalAttrs: {
 
     outputHash =
       {
-        x86_64-linux = lib.fakeSha256;
-        aarch64-linux = lib.fakeSha256;
-        aarch64-darwin = lib.fakeSha256;
+        x86_64-linux = "sha256-4oewElMoMU94puhN3spjcUQ4oLJjIJ6seDehJ+/93uc=";
+        aarch64-linux = "sha256-A9eO4CF28DNgRji/5WJc6SF+U9nTafcPjs7IH8jCeXQ=";
+        aarch64-darwin = "sha256-hXn60NmUxuzAoo+7fqXJI5ealdSG4GxjM9qUpf1d2OE=";
       }
       .${stdenv.hostPlatform.system}
         or (throw "gstack node_modules hash not available for ${stdenv.hostPlatform.system}");

--- a/packages/gstack/default.nix
+++ b/packages/gstack/default.nix
@@ -12,13 +12,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gstack";
-  version = "0-unstable-2026-05-21";
+  version = "0-unstable-2026-05-27";
 
   src = fetchFromGitHub {
     owner = "garrytan";
     repo = "gstack";
-    rev = "029356e1f0693f22cb1fa4524c9b0f28ceab5a1b";
-    hash = "sha256-AkRFEYAm5wDt01Hgp/0dQ2sH4Hm9a7saVtTG4OiKtCA=";
+    rev = "19770ea8b41da3e79c510a2c80d1aad3f34d4075";
+    hash = "sha256-OZWdaujIKki6dGP7l59vW8UclKYETYEEti8RWWy843g=";
   };
 
   # Fixed-output derivation for node_modules (network access allowed in sandbox)
@@ -54,9 +54,9 @@ stdenv.mkDerivation (finalAttrs: {
 
     outputHash =
       {
-        x86_64-linux = "sha256-4oewElMoMU94puhN3spjcUQ4oLJjIJ6seDehJ+/93uc=";
-        aarch64-linux = "sha256-A9eO4CF28DNgRji/5WJc6SF+U9nTafcPjs7IH8jCeXQ=";
-        aarch64-darwin = "sha256-hXn60NmUxuzAoo+7fqXJI5ealdSG4GxjM9qUpf1d2OE=";
+        x86_64-linux = lib.fakeSha256;
+        aarch64-linux = lib.fakeSha256;
+        aarch64-darwin = lib.fakeSha256;
       }
       .${stdenv.hostPlatform.system}
         or (throw "gstack node_modules hash not available for ${stdenv.hostPlatform.system}");

--- a/packages/zotero-mcp/default.nix
+++ b/packages/zotero-mcp/default.nix
@@ -8,14 +8,14 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "zotero-mcp";
-  version = "0.3.0";
+  version = "0.4.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "54yyyu";
     repo = "zotero-mcp";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-h23KyRDmFryBQ517oIzCKPSUXDBbpKvHItq7T20oPJw=";
+    hash = "sha256-o1h5DUmRwXrvep9MVmsAU0GpEknlIwXQbkBTL+4LC4M=";
   };
 
   build-system = with python3Packages; [


### PR DESCRIPTION
## Updated Dependencies

| Package | Type | Old Version | New Version |
|---------|------|-------------|-------------|
| zotero-mcp | tag | v0.3.0 | v0.4.1 |
| gstack | rev | 029356e1 (2026-05-21) | 19770ea8 (2026-05-27) |

## Unchanged Dependencies (already up to date)

| Package | Current Version |
|---------|----------------|
| gitmoji | v3.15.0 |
| paseo-relay | v0.5.0 |
| pmp-library | 3.0.0 |
| catppuccin/btop | f437574b (latest) |
| catppuccin/starship | 5906cc36 (latest) |
| anthropics/skills | 690f15ca (latest) |
| letieu/btw.nvim | 47f6419e (latest) |
| catppuccin/bat | 6810349b (latest) |
| catppuccin/yazi | 41f24ed1 (latest) |
| catppuccin/delta | 74b47a34 (latest) |

## Notes

- **gstack**: `node_modules` outputHash set to `lib.fakeSha256` for all platforms. CI will report the correct hashes for auto-fix.
- Source hashes computed with `nix-prefetch-url --unpack` + `nix hash convert --hash-algo sha256`.

