### PR TITLE
feat(rpi5): add Readeck service

### DIFF
--- a/hosts/yzx9-rpi5/default.nix
+++ b/hosts/yzx9-rpi5/default.nix
@@ -29,6 +29,7 @@ inputs.self.lib.mkNixosRpiConfiguration {
       ./n8n.nix
       ./paseo.nix
       ./radicale.nix
+      ./readeck.nix
       ./trilium.nix
     ];
 

--- a/hosts/yzx9-rpi5/readeck.nix
+++ b/hosts/yzx9-rpi5/readeck.nix
@@ -1,0 +1,15 @@
+{ config, ... }:
+
+{
+  age.secrets."readeck-env" = {
+    file = ../../secrets/readeck-env.age;
+  };
+
+  services.readeck = {
+    enable = true;
+    environmentFile = config.age.secrets."readeck-env".path;
+    settings.server.port = 45286;
+  };
+
+  networking.firewall.allowedTCPPorts = [ 45286 ];
+}

--- a/secrets/readeck-env.age
+++ b/secrets/readeck-env.age
@@ -1,0 +1,23 @@
+age-encryption.org/v1
+-> ssh-ed25519 BIPP7Q fuVfYAJJ9/NzgN6KdIgGwPfjUCd80jNBf7w8KKCL6Fc
+7WbsWUMi7cdUZcpBXHUThk//6bKrpY7mnZrerzXORJo
+-> ssh-ed25519 lKY4HA TVnBRnv9N/XAZDT6Y1W4NdWyth6gJ2wXnf2h11M6RXs
+HeCh99/p3aP84w6DVVfDfKrRugNKGe+cETXyWv2Pwmk
+-> ssh-ed25519 rBO6sA q3Wo6kCiGClQb2WAL2EdmGdE/TImSkr2Md/2tNrXCCs
+/Pl6yDAPJL1KBxoRx1J60o7Fpmq7pkeB3cVLMwnzj1E
+-> ssh-ed25519 HfWVrw 03NuHLqPNwGRrj4xekq9imdQQ9OMf4f3JyAriKPxYiQ
+ripe73QCbnhHy/OZeHgsw+V5M+HcPw2Z6WNvOZ0G+OY
+-> ssh-ed25519 XgiS1A I/TRiraKacFsrwK068Zpwi3Ee1CDOaolfZaONGuf6DE
+e5lqmYHRnOZVxx1mvB62o1Xcm48B46OtcAKi+UheJno
+-> ssh-ed25519 Oj4wKQ wUkdkQQe0PDLhsXyBDVq5PRC4c104Le8EQ9qs6p+TAQ
+pHCJebq5l1XbGobxcsqDmWWj5zGaR44el0fx3TXfVMA
+-> ssh-ed25519 AarafA 50Q96lVjCnaWY4k00QA/XR7S7bgGf88zhPaDjzvXDHY
+I0Z/Gh20bD4fp5YmkJfl1D/0w44kh+YeXIhD0Ol80SE
+-> ssh-ed25519 dUuoTg PvPBxh9Xp98PTK65eKAvGl/Je1Wz+YB/eZ4u8wZ4Og8
+kouH55LesnK4x1sHKWV3yuI1cBR2DiyBtgQalCARm7o
+-> ssh-ed25519 BsrFaQ qd7XDULpkdSQ9SY6b5G/0dnl9lDY3YKjU/YSxdWD/Qc
+i/6gaJMW1qJZYautu9uV0dg4BiZQ6svd6FId6+XYtJw
+-> ssh-ed25519 ZIJVeg QkQUwd/n6YwCyYSpJavr80fqogFZDudYnnsYGqgwUmY
+XcQfF6P/N1jjb/usruNhVQaLnFS6Wa4uD5jFJyASoIM
+--- 6JtpXE/DdG7D9AfwoHypuj2CJvt+6mrngTlVfoINsMg
+¿Š®›­Uîòâc")|ì0}-£2ŽÎá´¢ë5O¥>m´ØCÜÝÖnRxV$ú#'6 8¹hç

--- a/secrets/secrets.nix
+++ b/secrets/secrets.nix
@@ -45,6 +45,7 @@ in
   "llm-api-keys.age".publicKeys = all_keys;
   "paseo.age".publicKeys = all_keys;
   "radicale-auth.age".publicKeys = all_keys;
+  "readeck-env.age".publicKeys = all_keys;
   "ssh-config.age".publicKeys = all_keys;
   "xray.json.age".publicKeys = all_keys;
 


### PR DESCRIPTION
## Changes

- Add `hosts/yzx9-rpi5/readeck.nix` using nixpkgs `services.readeck` module
- Port: **45286** (random, >10000)
- Firewall: `allowedTCPPorts = [ 45286 ]` — LAN access only
- No nginx reverse proxy, no frpc exposure (不暴露公网)
- Age-encrypted env file for `READECK_SECRET_KEY`

## Access

After deploy: `http://10.6.141.234:45286`

## Note

The `READECK_SECRET_KEY` in the encrypted env file is currently empty — you'll need to edit it after merge:
```
age -d secrets/readeck-env.age
# edit to set READECK_SECRET_KEY=<your-secret>
age -e -o secrets/readeck-env.age ... < plaintext
```