### PR TITLE
chore: upgrade self-packaged dependencies (2026-06-05)

### DIFF
--- a/home/ai/claude-code.nix
+++ b/home/ai/claude-code.nix
@@ -455,8 +455,8 @@ in
         awesome-subagents = pkgs.fetchFromGitHub {
           owner = "VoltAgent";
           repo = "awesome-claude-code-subagents";
-          rev = "945f491f0f453dfd735262d4d98825a5227ac301";
-          hash = "sha256-XBSYxi2qZMbmTOKLTnSmmvSMyrnGzT4WiSeUOcVyYEU=";
+          rev = "2f9cf8b9562dcc235cc2296bda6df82d60e800be";
+          hash = "sha256-ywObyscvl+/hnZMGJvWnqebS5gHBICMbMl4OabY10ys=";
         };
 
         # PERF: remove readFile

--- a/home/ai/skills.nix
+++ b/home/ai/skills.nix
@@ -4,8 +4,8 @@ let
   anthropics-skills = pkgs.fetchFromGitHub {
     owner = "anthropics";
     repo = "skills";
-    rev = "690f15cac7f7b4c055c5ab109c79ed9259934081";
-    hash = "sha256-GMXFJSePrpEvhzMQ82YI9Z10BDkuFK/lXUDELclvQ4c=";
+    rev = "da20c92503b2e8ff1cf28ca81a0df4673debdbf7";
+    hash = "sha256-BiZvEV7VK1AwhiGg+pNMgTUQmt4exevLWwL0Brx4YyE=";
   };
 in
 {

--- a/home/delta.nix
+++ b/home/delta.nix
@@ -11,8 +11,8 @@ let
   catppuccin = pkgs.fetchFromGitHub {
     owner = "catppuccin";
     repo = "delta";
-    rev = "74b47a345638a2f19b3e5bdb9d7e4984066f9ac7";
-    hash = "sha256-NjqqB/BHqduiNWKeksiRZUMfjRUodJlsVu1yaEIZRsM=";
+    rev = "011516f5d14f66b771b3e716f29c77231e008c74";
+    hash = "sha256-lztkxX9O41YossvRzpR7tqxMhDNT1Efy2JvkCwtsiXQ=";
   };
 in
 {


### PR DESCRIPTION
## Updated dependencies

| Dependency | File | Old Rev | New Rev | Notes |
|---|---|---|---|---|
| [anthropics/skills](https://github.com/anthropics/skills) | `home/ai/skills.nix` | `690f15c` | `da20c925` | Latest commit on main |
| [VoltAgent/awesome-claude-code-subagents](https://github.com/VoltAgent/awesome-claude-code-subagents) | `home/ai/claude-code.nix` | `945f491` | `2f9cf8b` | Latest commit on main |
| [catppuccin/delta](https://github.com/catppuccin/delta) | `home/delta.nix` | `74b47a3` | `011516f` | Latest commit on main |

## Already up to date (no changes needed)

| Dependency | File | Rev/Tag | Status |
|---|---|---|---|
| catppuccin/btop | `home/btop.nix` | `f437574` | Up to date |
| catppuccin/starship | `home/shell.nix` | `5906cc3` | Up to date |
| catppuccin/bat | `packages/catppuccin-bat/default.nix` | `6810349` | Up to date |
| catppuccin/yazi | `packages/catppuccin-yazi-flavor/default.nix` | `41f24ed` | Up to date |
| 54yyyu/zotero-mcp | `packages/zotero-mcp/default.nix` | v0.4.1 | Latest release |
| letieu/btw.nvim | `packages/nixvim/plugins-ui/btw.nix` | `47f6419` | Up to date (no new commits) |
| zenghongtu/paseo-relay | `packages/paseo-relay/default.nix` | v0.5.0 | Latest release |
| pmp-library/pmp-library | `packages/pmp-library/default.nix` | 3.0.0 | Latest release |

## Update available but skipped

| Dependency | File | Old Rev | New Rev | Reason |
|---|---|---|---|---|
| [garrytan/gstack](https://github.com/garrytan/gstack) | `packages/gstack/default.nix` | `19770ea` | `cab774c` | Requires `bun` for node_modules hash recomputation (platform-specific fixed-output derivations) |

---

*Automated check by Hermes cron job.*