### PR TITLE
chore: upgrade self-packaged dependencies (2026-06-12)

### DIFF
--- a/home/ai/claude-code.nix
+++ b/home/ai/claude-code.nix
@@ -507,8 +507,8 @@ in
         awesome-subagents = pkgs.fetchFromGitHub {
           owner = "VoltAgent";
           repo = "awesome-claude-code-subagents";
-          rev = "945f491f0f453dfd735262d4d98825a5227ac301";
-          hash = "sha256-XBSYxi2qZMbmTOKLTnSmmvSMyrnGzT4WiSeUOcVyYEU=";
+          rev = "2f9cf8b9562dcc235cc2296bda6df82d60e800be";
+          hash = "sha256-ywObyscvl+/hnZMGJvWnqebS5gHBICMbMl4OabY10ys=";
         };
 
         # PERF: remove readFile

--- a/home/ai/skills.nix
+++ b/home/ai/skills.nix
@@ -4,8 +4,8 @@ let
   anthropics-skills = pkgs.fetchFromGitHub {
     owner = "anthropics";
     repo = "skills";
-    rev = "690f15cac7f7b4c055c5ab109c79ed9259934081";
-    hash = "sha256-GMXFJSePrpEvhzMQ82YI9Z10BDkuFK/lXUDELclvQ4c=";
+    rev = "57546260929473d4e0d1c1bb75297be2fdfa1949";
+    hash = "sha256-1D9otXxDvmKASBu/vtAEWv6kE+U+jG4OxZpRLZbGEF0=";
   };
 in
 {

--- a/home/delta.nix
+++ b/home/delta.nix
@@ -11,8 +11,8 @@ let
   catppuccin = pkgs.fetchFromGitHub {
     owner = "catppuccin";
     repo = "delta";
-    rev = "74b47a345638a2f19b3e5bdb9d7e4984066f9ac7";
-    hash = "sha256-NjqqB/BHqduiNWKeksiRZUMfjRUodJlsVu1yaEIZRsM=";
+    rev = "011516f5d14f66b771b3e716f29c77231e008c74";
+    hash = "sha256-lztkxX9O41YossvRzpR7tqxMhDNT1Efy2JvkCwtsiXQ=";
   };
 in
 {

--- a/packages/gstack/default.nix
+++ b/packages/gstack/default.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     outputHash =
       {
-        x86_64-linux = "sha256-o36m2aYuieuGJi1mxAZiCR9ENsMNow+quO1NqRCMiB4=";
+        x86_64-linux = "sha256-4oewElMoMU94puhN3spjcUQ4oLJjIJ6seDehJ+/93uc=";
         aarch64-linux = "sha256-A9eO4CF28DNgRji/5WJc6SF+U9nTafcPjs7IH8jCeXQ=";
         aarch64-darwin = "sha256-hXn60NmUxuzAoo+7fqXJI5ealdSG4GxjM9qUpf1d2OE=";
       }

--- a/packages/gstack/default.nix
+++ b/packages/gstack/default.nix
@@ -12,13 +12,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gstack";
-  version = "0-unstable-2026-05-27";
+  version = "0-unstable-2026-06-11";
 
   src = fetchFromGitHub {
     owner = "garrytan";
     repo = "gstack";
-    rev = "19770ea8b41da3e79c510a2c80d1aad3f34d4075";
-    hash = "sha256-OZWdaujIKki6dGP7l59vW8UclKYETYEEti8RWWy843g=";
+    rev = "a5833c413f98b13f105beac96262e8098b628461";
+    hash = "sha256-NWgf2l6Hdje4W8SyzBOK85/YqznJuToWxrwvzxTMZyo=";
   };
 
   # Fixed-output derivation for node_modules (network access allowed in sandbox)
@@ -54,7 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     outputHash =
       {
-        x86_64-linux = "sha256-4oewElMoMU94puhN3spjcUQ4oLJjIJ6seDehJ+/93uc=";
+        x86_64-linux = "sha256-o36m2aYuieuGJi1mxAZiCR9ENsMNow+quO1NqRCMiB4=";
         aarch64-linux = "sha256-A9eO4CF28DNgRji/5WJc6SF+U9nTafcPjs7IH8jCeXQ=";
         aarch64-darwin = "sha256-hXn60NmUxuzAoo+7fqXJI5ealdSG4GxjM9qUpf1d2OE=";
       }

--- a/packages/zotero-mcp/default.nix
+++ b/packages/zotero-mcp/default.nix
@@ -8,14 +8,14 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "zotero-mcp";
-  version = "0.4.1";
+  version = "0.5.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "54yyyu";
     repo = "zotero-mcp";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-o1h5DUmRwXrvep9MVmsAU0GpEknlIwXQbkBTL+4LC4M=";
+    hash = "sha256-ioy6bdP+jFioUGBKiiYtD4nbdFe6v2E3nCi6s9+dTT0=";
   };
 
   build-system = with python3Packages; [


### PR DESCRIPTION
## Dependency Updates

Automated update check found 5 dependencies with available updates:

| Dependency | Previous | Updated |
|---|---|---|
| anthropics/skills | 690f15c | 5754626 |
| catppuccin/delta | 74b47a3 | 011516f |
| VoltAgent/awesome-claude-code-subagents | 945f491 | 2f9cf8b |
| garrytan/gstack | 19770ea (2026-05-27) | a5833c4 (2026-06-11) |
| 54yyyu/zotero-mcp | v0.4.1 | v0.5.0 |

### Already up to date

- catppuccin/btop, catppuccin/starship, letieu/btw.nvim, catppuccin/yazi, catppuccin/bat
- zenghongtu/paseo-relay (v0.5.0), pmp-library/pmp-library (3.0.0)

### Notes

- gstack: Only x86_64-linux node_modules hash was computed. aarch64 hashes may need updating.
- zotero-mcp: Version bump 0.4.1 to 0.5.0. Check if new Python deps are needed.

Auto-generated by Hermes cron job.
