### PR TITLE
chore: upgrade self-packaged dependencies

### DIFF
--- a/packages/catppuccin-yazi-flavor/default.nix
+++ b/packages/catppuccin-yazi-flavor/default.nix
@@ -9,13 +9,13 @@
 
 stdenvNoCC.mkDerivation {
   pname = "catppuccin-yazi";
-  version = "0-unstable-2026-05-14";
+  version = "0-unstable-2026-06-13";
 
   src = fetchFromGitHub {
     owner = "catppuccin";
     repo = "yazi";
-    rev = "41f24ed142e34109a9a65a5dfe58c1b4eb6d2fd9";
-    hash = "sha256-Og33IGS9pTim6LEH33CO102wpGnPomiperFbqfgrJjw=";
+    rev = "baaf5d1c9427b836fbefd126aa855f9eab7a9d0d";
+    hash = "sha256-L6SApM07CSQk0znEsFP8WaxW+ZHcindXo612r1XcwIg=";
   };
 
   nativeBuildInputs = [

--- a/packages/gstack/default.nix
+++ b/packages/gstack/default.nix
@@ -12,13 +12,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gstack";
-  version = "0-unstable-2026-06-11";
+  version = "0-unstable-2026-06-18";
 
   src = fetchFromGitHub {
     owner = "garrytan";
     repo = "gstack";
-    rev = "a5833c413f98b13f105beac96262e8098b628461";
-    hash = "sha256-NWgf2l6Hdje4W8SyzBOK85/YqznJuToWxrwvzxTMZyo=";
+    rev = "a861c00cfac6e2376d26c7d3ba5207cdc5aefc49";
+    hash = "sha256-IXIUpGWAKjurJB5guLhS2K1Cqg3vraWU/JjSF9AbSFg=";
   };
 
   # Fixed-output derivation for node_modules (network access allowed in sandbox)
@@ -54,7 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     outputHash =
       {
-        x86_64-linux = "sha256-4oewElMoMU94puhN3spjcUQ4oLJjIJ6seDehJ+/93uc=";
+        x86_64-linux = "sha256-li8lSzejX6bDrVKmpZ08Xw0eoyxxBtTRO4swzIXJfp4=";
         aarch64-linux = "sha256-A9eO4CF28DNgRji/5WJc6SF+U9nTafcPjs7IH8jCeXQ=";
         aarch64-darwin = "sha256-hXn60NmUxuzAoo+7fqXJI5ealdSG4GxjM9qUpf1d2OE=";
       }

--- a/packages/gstack/default.nix
+++ b/packages/gstack/default.nix
@@ -55,8 +55,8 @@ stdenv.mkDerivation (finalAttrs: {
     outputHash =
       {
         x86_64-linux = "sha256-li8lSzejX6bDrVKmpZ08Xw0eoyxxBtTRO4swzIXJfp4=";
-        aarch64-linux = "sha256-A9eO4CF28DNgRji/5WJc6SF+U9nTafcPjs7IH8jCeXQ=";
-        aarch64-darwin = "sha256-hXn60NmUxuzAoo+7fqXJI5ealdSG4GxjM9qUpf1d2OE=";
+        aarch64-linux = "sha256-sljp67vnOiZsu09O2b9S3bgjeEeZi5ico4sFqNVgsFs=";
+        aarch64-darwin = "sha256-TJBN/fEcAaM5/knt5D2SULVHf+StRG5w6lSebUWUd6s=";
       }
       .${stdenv.hostPlatform.system}
         or (throw "gstack node_modules hash not available for ${stdenv.hostPlatform.system}");


### PR DESCRIPTION
## Summary

Automated check for updates to self-packaged `fetchFromGitHub` dependencies.

### Updates available (2 of 12 dependencies)

| Dependency | File | Old | New |
|---|---|---|---|
| **catppuccin/yazi** | `packages/catppuccin-yazi-flavor/default.nix` | `41f24ed` (2026-05-14) | `baaf5d1` (2026-06-13) |
| **garrytan/gstack** | `packages/gstack/default.nix` | `a5833c4` (2026-06-11) | `a861c00` (2026-06-18) |

### Already up to date (10 dependencies)

- pmp-library/pmp-library (3.0.0)
- catppuccin/bat (6810349)
- 54yyyu/zotero-mcp (v0.5.0)
- letieu/btw.nvim (47f6419)
- zenghongtu/paseo-relay (v0.5.0)
- Joedmin/xExtension-readeck-button (0.14)
- catppuccin/starship (5906cc3)
- catppuccin/delta (011516f)
- anthropics/skills (5754626)
- catppuccin/btop (f437574)

### Verification

- catppuccin-yazi: builds successfully on x86_64-linux
- gstack src hash: verified via nix build
- gstack node_modules (x86_64-linux): FOD hash verified by building

### Known limitation

The `bun.lock` changed in gstack, so `node_modules` hashes for **aarch64-linux** and **aarch64-darwin** also need updating. These could not be computed without cross-compilation support (no binfmt/QEMU available). The old hashes are left in place - builds on those platforms will fail with a hash mismatch error showing the correct hash.

---
_Generated by automated dependency check._