### PR TITLE
chore: upgrade self-packaged dependencies

### DIFF
--- a/packages/gstack/default.nix
+++ b/packages/gstack/default.nix
@@ -12,13 +12,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gstack";
-  version = "0-unstable-2026-06-18";
+  version = "0-unstable-2026-06-25";
 
   src = fetchFromGitHub {
     owner = "garrytan";
     repo = "gstack";
-    rev = "a861c00cfac6e2376d26c7d3ba5207cdc5aefc49";
-    hash = "sha256-IXIUpGWAKjurJB5guLhS2K1Cqg3vraWU/JjSF9AbSFg=";
+    rev = "11de390be1be6849eb9a15f91ff4922dd16c589a";
+    hash = "sha256-ZVnY33E7b6j200PyN0zrOjxu1yjKfi55jLWSMp6MbL8=";
   };
 
   # Fixed-output derivation for node_modules (network access allowed in sandbox)

--- a/packages/zotero-mcp/default.nix
+++ b/packages/zotero-mcp/default.nix
@@ -8,14 +8,14 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "zotero-mcp";
-  version = "0.5.0";
+  version = "0.6.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "54yyyu";
     repo = "zotero-mcp";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ioy6bdP+jFioUGBKiiYtD4nbdFe6v2E3nCi6s9+dTT0=";
+    hash = "sha256-E7l+3aOwPEGUpDB5wnpWEhR+Gvaj8KZNxFliakursD8=";
   };
 
   build-system = with python3Packages; [


### PR DESCRIPTION
## Summary

Automated check for updates to self-packaged dependencies using `fetchFromGitHub`.

### Updates

| Package | File | Old | New |
|---------|------|-----|-----|
| **zotero-mcp** | `packages/zotero-mcp/default.nix` | v0.5.0 | **v0.6.0** |
| **gstack** | `packages/gstack/default.nix` | `a861c00c` (2026-06-18) | `11de390b` (2026-06-25) |

### Already up to date (10 deps)

- paseo-relay (v0.5.0)
- pmp-library (3.0.0)
- catppuccin/yazi (baaf5d1c)
- catppuccin/bat (6810349b)
- btw.nvim (47f6419e)
- catppuccin/btop (f437574b)
- catppuccin/starship (5906cc36)
- anthropics/skills (57546260)
- catppuccin/delta (011516f5)
- xExtension-readeck-button (0.14)

### Verification

- Source hashes computed with `nix-prefetch-url`
- gstack `node_modules` hash verified unchanged (bun.lock identical between commits)
- Built `gstack.node_modules` successfully to confirm hash correctness