### PR TITLE
⬆️ chore: upgrade self-packaged dependencies

### DIFF
--- a/home/ai/claude-code.nix
+++ b/home/ai/claude-code.nix
@@ -601,8 +601,8 @@ in
         awesome-subagents = pkgs.fetchFromGitHub {
           owner = "VoltAgent";
           repo = "awesome-claude-code-subagents";
-          rev = "2f9cf8b9562dcc235cc2296bda6df82d60e800be";
-          hash = "sha256-ywObyscvl+/hnZMGJvWnqebS5gHBICMbMl4OabY10ys=";
+          rev = "c193ad45419c13ceb49a43740186f680ad5ea264";
+          hash = "sha256-qG9VLe6HdjcJ5EhHYByh5Vy+2mpd8i7K7fwdyHL8L8k=";
         };
 
         # PERF: remove readFile

--- a/home/ai/skills.nix
+++ b/home/ai/skills.nix
@@ -4,8 +4,8 @@ let
   anthropics-skills = pkgs.fetchFromGitHub {
     owner = "anthropics";
     repo = "skills";
-    rev = "57546260929473d4e0d1c1bb75297be2fdfa1949";
-    hash = "sha256-1D9otXxDvmKASBu/vtAEWv6kE+U+jG4OxZpRLZbGEF0=";
+    rev = "9d2f1ae187231d8199c64b5b762e1bdf2244733d";
+    hash = "sha256-U7Nt1xrFOSOEm4vuWmy4pVsEyvv+Hj4sv8yXOofmwAw=";
   };
 in
 {


### PR DESCRIPTION
## Summary

Automated update of self-packaged dependencies pinned via `fetchFromGitHub`.

### Updates

| Dependency | File | Change |
|---|---|---|
| [anthropics/skills](https://github.com/anthropics/skills) | `home/ai/skills.nix` | `5754626` → `9d2f1ae` |
| [VoltAgent/awesome-claude-code-subagents](https://github.com/VoltAgent/awesome-claude-code-subagents) | `home/ai/claude-code.nix` | `2f9cf8b` → `c193ad4` |

### Details

- **anthropics/skills**: Update claude-api skill: Claude Sonnet 5 and Managed Agents July updates (#1373)
- **VoltAgent/awesome-claude-code-subagents**: update README

All other self-packaged dependencies (catppuccin themes, zotero-mcp, paseo-relay, pmp-library, gstack, btw.nvim, etc.) are already up to date.
