### PR TITLE
chore: upgrade self-packaged dependencies

### DIFF
--- a/home/ai/skills.nix
+++ b/home/ai/skills.nix
@@ -12,8 +12,8 @@ let
   matt-skills = pkgs.fetchFromGitHub {
     owner = "mattpocock";
     repo = "skills";
-    rev = "d574778f94cf620fcc8ce741584093bc650a61d3";
-    hash = "sha256-XqF709Y9GMKINzZITlbCTyatG9AxRZh0qn2vcv1Z8yo=";
+    rev = "9603c1cc8118d08bc1b3bf34cf714f62178dea3b";
+    hash = "sha256-0ha4c5fp4ign40qds26f13id78b0ndp1dpd5if96383xmx241ajb=";
   };
 in
 {

--- a/packages/gstack/default.nix
+++ b/packages/gstack/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "garrytan";
     repo = "gstack";
     rev = "a3259400a366593e0c909dd9ac3e59752efd2488";
-    hash = "sha256-1543yijl9pfxr5ks651xlhnrk658ys79j8z3vjwxi68wddqykgv6=";
+    hash = "sha256-Zr/pcWscmdi53OMjmY72qJiZLaQ9FKNnyd3dRGX0g5Q=";
   };
 
   # Fixed-output derivation for node_modules (network access allowed in sandbox)

--- a/packages/gstack/default.nix
+++ b/packages/gstack/default.nix
@@ -12,13 +12,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gstack";
-  version = "0-unstable-2026-06-25";
+  version = "0-unstable-2026-07-15";
 
   src = fetchFromGitHub {
     owner = "garrytan";
     repo = "gstack";
-    rev = "11de390be1be6849eb9a15f91ff4922dd16c589a";
-    hash = "sha256-ZVnY33E7b6j200PyN0zrOjxu1yjKfi55jLWSMp6MbL8=";
+    rev = "a3259400a366593e0c909dd9ac3e59752efd2488";
+    hash = "sha256-1543yijl9pfxr5ks651xlhnrk658ys79j8z3vjwxi68wddqykgv6=";
   };
 
   # Fixed-output derivation for node_modules (network access allowed in sandbox)

--- a/packages/gstack/default.nix
+++ b/packages/gstack/default.nix
@@ -54,9 +54,9 @@ stdenv.mkDerivation (finalAttrs: {
 
     outputHash =
       {
-        x86_64-linux = "sha256-li8lSzejX6bDrVKmpZ08Xw0eoyxxBtTRO4swzIXJfp4=";
-        aarch64-linux = "sha256-sljp67vnOiZsu09O2b9S3bgjeEeZi5ico4sFqNVgsFs=";
-        aarch64-darwin = "sha256-TJBN/fEcAaM5/knt5D2SULVHf+StRG5w6lSebUWUd6s=";
+        x86_64-linux = "sha256-4ydW9f/svvMEMTZN1lk4C5uoUxxxDyFdKTSu8c8bxgo=";
+        aarch64-linux = "sha256-r1+VP34SiAVBm/l1QvIr238ha5Su3THFA9aAn6cpZ/E=";
+        aarch64-darwin = "sha256-wC/aKWuEnShhAKK0MXXtS5z8zZLYg2Q5rPJHuAk2OsM=";
       }
       .${stdenv.hostPlatform.system}
         or (throw "gstack node_modules hash not available for ${stdenv.hostPlatform.system}");


### PR DESCRIPTION
Updates two self-packaged dependencies:

**mattpocock/skills** (home/ai/skills.nix): `d574778` → `9603c1c` (2026-07-16)
**garrytan/gstack** (packages/gstack/default.nix): `11de390` → `a325940` (2026-07-15)

> ⚠️ The gstack `node_modules` output hashes in `packages/gstack/default.nix` are now stale and need to be recomputed on the next build. Nix will emit the correct hashes in the build error message.