### PR TITLE
chore: upgrade self-packaged dependencies

### DIFF
--- a/home/ai/claude-code.nix
+++ b/home/ai/claude-code.nix
@@ -597,8 +597,8 @@ in
         awesome-subagents = pkgs.fetchFromGitHub {
           owner = "VoltAgent";
           repo = "awesome-claude-code-subagents";
-          rev = "977dfeaaf3d2252a8ace0c68438d08d39965ed43";
-          hash = "sha256-kRDbIuai2m5aFU+U2ZpbZyt7kAAkKMlJhTHEGMzwfaE=";
+          rev = "947b44ca0c58d606b084e9cb1a2389335b49278b";
+          hash = "sha256-9tl3CpNQ2JnZWWCh9luiYoh4MWTSOheaxicP8qpENJc=";
         };
 
         # PERF: remove readFile

--- a/home/ai/skills.nix
+++ b/home/ai/skills.nix
@@ -4,16 +4,16 @@ let
   anthropics-skills = pkgs.fetchFromGitHub {
     owner = "anthropics";
     repo = "skills";
-    rev = "9d2f1ae187231d8199c64b5b762e1bdf2244733d";
-    hash = "sha256-U7Nt1xrFOSOEm4vuWmy4pVsEyvv+Hj4sv8yXOofmwAw=";
+    rev = "1f630fdf9259cec4a14913127dfd7c3b69ef72eb";
+    hash = "sha256-XPXKd05IEiyTPlAPkowfJUal1UfRlxEHo+GgszgHQCI=";
   };
 
   # https://github.com/mattpocock/skills — "Skills For Real Engineers"
   matt-skills = pkgs.fetchFromGitHub {
     owner = "mattpocock";
     repo = "skills";
-    rev = "9603c1cc8118d08bc1b3bf34cf714f62178dea3b";
-    hash = "sha256-S6pARK99oGGSi6XdFm6zYKHT4gjOCN0wIPZFcl1hREE=";
+    rev = "d574778f94cf620fcc8ce741584093bc650a61d3";
+    hash = "sha256-XqF709Y9GMKINzZITlbCTyatG9AxRZh0qn2vcv1Z8yo=";
   };
 in
 {


### PR DESCRIPTION
Updates three self-packaged dependencies:

- **anthropics/skills**: 9d2f1ae → 1f630fd (latest HEAD on default branch)
- **mattpocock/skills**: 9603c1c → v1.1.0 (d574778) (new release)
- **VoltAgent/awesome-claude-code-subagents**: 977dfea → 947b44c (latest HEAD on default branch)

All hashes computed and verified via nix-prefetch-url.