### PR TITLE
chore: upgrade self-packaged dependencies (skills repos)

### DIFF
--- a/home/ai/claude-code.nix
+++ b/home/ai/claude-code.nix
@@ -588,8 +588,8 @@ in
         awesome-subagents = pkgs.fetchFromGitHub {
           owner = "VoltAgent";
           repo = "awesome-claude-code-subagents";
-          rev = "947b44ca0c58d606b084e9cb1a2389335b49278b";
-          hash = "sha256-9tl3CpNQ2JnZWWCh9luiYoh4MWTSOheaxicP8qpENJc=";
+          rev = "91810b33c707111e05e0988b12e7385d7b5cfe9d";
+          hash = "sha256-5IHgwLBLGCYR6W79PpttXaFScMOOyL/9HoulBQXim10=";
         };
 
         # PERF: remove readFile

--- a/home/ai/skills.nix
+++ b/home/ai/skills.nix
@@ -4,16 +4,16 @@ let
   anthropics-skills = pkgs.fetchFromGitHub {
     owner = "anthropics";
     repo = "skills";
-    rev = "1f630fdf9259cec4a14913127dfd7c3b69ef72eb";
-    hash = "sha256-XPXKd05IEiyTPlAPkowfJUal1UfRlxEHo+GgszgHQCI=";
+    rev = "b29e7cf65e5cb78a5ac33d582270551bc74a14eb";
+    hash = "sha256-RH2B03gj4kzw1j5LORezgUZPPu8mW+mWb+Kl2U7WUbY=";
   };
 
   # https://github.com/mattpocock/skills — "Skills For Real Engineers"
   matt-skills = pkgs.fetchFromGitHub {
     owner = "mattpocock";
     repo = "skills";
-    rev = "d574778f94cf620fcc8ce741584093bc650a61d3";
-    hash = "sha256-XqF709Y9GMKINzZITlbCTyatG9AxRZh0qn2vcv1Z8yo=";
+    rev = "84fdeffd12f2ee307994d1eb6feb48173b6e0502";
+    hash = "sha256-pseSJJb5nBBGPzpxA1GzjGLB9OrT+u0At1saJ4NqZ1E=";
   };
 in
 {


### PR DESCRIPTION
## Changes

- **anthropics/skills**: 1f630fd -> b29e7cf (skill-creator path verified at new rev)
- **mattpocock/skills**: d574778 -> 84fdeff (grill-me/grilling paths verified)
- **VoltAgent/awesome-claude-code-subagents**: 947b44c -> 91810b3 (referenced category files verified)

All new hashes computed via `nix-prefetch-url --unpack` and verified by real fetchFromGitHub evaluation.

## Not included (intentional)

**zotero-mcp 0.6.2 -> 0.9.1**: upstream 0.8.0+ depends on `pdf-inspector`, which is not packaged in nixpkgs (checked pinned rev 104240a and master) — adding it would break flake eval (`attribute 'pdf-inspector' missing`). 0.9.0 also renamed 15 MCP tools, which would break the claude-code.nix permission allowlist (get_*/list_*/search_*/create_note etc.). Needs separate follow-up: package pdf-inspector (Rust, abi3 wheels) and update the allowlist.