### PR TITLE
chore: upgrade self-packaged dependencies

### DIFF
--- a/home/ai/claude-code.nix
+++ b/home/ai/claude-code.nix
@@ -536,8 +536,8 @@ in
         awesome-subagents = pkgs.fetchFromGitHub {
           owner = "VoltAgent";
           repo = "awesome-claude-code-subagents";
-          rev = "91810b33c707111e05e0988b12e7385d7b5cfe9d";
-          hash = "sha256-5IHgwLBLGCYR6W79PpttXaFScMOOyL/9HoulBQXim10=";
+          rev = "c9e51ec0b3d43f5dcdd0b558a6cd28ba6ada97c1";
+          hash = "sha256-TM2sk+QPsNalM81sXVcBDI4tjh3Rqa5mIvF95C7Xxkc=";
         };
 
         # PERF: remove readFile

--- a/home/ai/skills.nix
+++ b/home/ai/skills.nix
@@ -4,16 +4,16 @@ let
   anthropics-skills = pkgs.fetchFromGitHub {
     owner = "anthropics";
     repo = "skills";
-    rev = "b29e7cf65e5cb78a5ac33d582270551bc74a14eb";
-    hash = "sha256-RH2B03gj4kzw1j5LORezgUZPPu8mW+mWb+Kl2U7WUbY=";
+    rev = "f6656c1256d5a8adfa37db9110046ef20bac644c";
+    hash = "sha256-5/0f5AnGWX3oM+M9Xm/zSmooz11+S1YRdFPmAX+DXi0=";
   };
 
   # https://github.com/mattpocock/skills — "Skills For Real Engineers"
   matt-skills = pkgs.fetchFromGitHub {
     owner = "mattpocock";
     repo = "skills";
-    rev = "84fdeffd12f2ee307994d1eb6feb48173b6e0502";
-    hash = "sha256-pseSJJb5nBBGPzpxA1GzjGLB9OrT+u0At1saJ4NqZ1E=";
+    rev = "8b78b531ab965735c5dc74f6f7a219e1e37326df";
+    hash = "sha256-jsXcMkhu15MxR0zXnLLJeni0q0Aew2UxUSojl6zmOvg=";
   };
 in
 {

--- a/packages/gstack/default.nix
+++ b/packages/gstack/default.nix
@@ -15,13 +15,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gstack";
-  version = "0-unstable-2026-07-15";
+  version = "0-unstable-2026-08-12";
 
   src = fetchFromGitHub {
     owner = "garrytan";
     repo = "gstack";
-    rev = "a3259400a366593e0c909dd9ac3e59752efd2488";
-    hash = "sha256-Zr/pcWscmdi53OMjmY72qJiZLaQ9FKNnyd3dRGX0g5Q=";
+    rev = "d078622b73539fc1a7a27e709861e9b6b058ae98";
+    hash = "sha256-28fkbcY/VFAq9W9LF8Bpq2SqHZnncKOdRhmuRZh5AdU=";
   };
 
   # Fixed-output derivation for node_modules (network access allowed in sandbox)
@@ -57,7 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     outputHash =
       {
-        x86_64-linux = "sha256-4ydW9f/svvMEMTZN1lk4C5uoUxxxDyFdKTSu8c8bxgo=";
+        x86_64-linux = "sha256-431ySVkJD9VWJfP/oueTXCBOmiyY0mPsSA27nTTrL24=";
         aarch64-linux = "sha256-r1+VP34SiAVBm/l1QvIr238ha5Su3THFA9aAn6cpZ/E=";
         aarch64-darwin = "sha256-wC/aKWuEnShhAKK0MXXtS5z8zZLYg2Q5rPJHuAk2OsM=";
       }

--- a/packages/gstack/default.nix
+++ b/packages/gstack/default.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     outputHash =
       {
-        x86_64-linux = "sha256-431ySVkJD9VWJfP/oueTXCBOmiyY0mPsSA27nTTrL24=";
+        x86_64-linux = "sha256-4ydW9f/svvMEMTZN1lk4C5uoUxxxDyFdKTSu8c8bxgo=";
         aarch64-linux = "sha256-r1+VP34SiAVBm/l1QvIr238ha5Su3THFA9aAn6cpZ/E=";
         aarch64-darwin = "sha256-wC/aKWuEnShhAKK0MXXtS5z8zZLYg2Q5rPJHuAk2OsM=";
       }


### PR DESCRIPTION
## 更新内容

自动检查 13 个 fetchFromGitHub 依赖，4 个有新提交，已升级：

| 依赖 | 旧 rev/tag | 新 rev/tag |
|---|---|---|
| anthropics/skills | b29e7cf | f6656c1 |
| mattpocock/skills | 84fdeff | 8b78b53 |
| VoltAgent/awesome-claude-code-subagents | 91810b3 | c9e51ec |
| garrytan/gstack | a325940 (2026-07-15) | d078622 (2026-08-12, v1.62.0.0) |

### 说明
- **gstack**: 已本地重新计算 x86_64-linux node_modules hash（bun install 复现）；aarch64-linux / aarch64-darwin hash 保持旧值，等待 CI 报错后由 PR checker 自动修正。
- **zotero-mcp (54yyyu/zotero-mcp)**: 跳过。v0.9.1 依赖 `pdf-inspector==0.2.6`，在锁定的 nixpkgs rev (d482ef84) 中不存在，升级会破坏 flake eval（已知问题，需单独 PR 处理）。

其余 8 个依赖（catppuccin/*, pmp-library, Joedmin/xExtension-readeck-button, letieu/btw.nvim）已是最新，未改动。