### PR TITLE
chore: upgrade self-packaged dependencies

### DIFF
--- a/home/ai/skills.nix
+++ b/home/ai/skills.nix
@@ -4,16 +4,16 @@ let
   anthropics-skills = pkgs.fetchFromGitHub {
     owner = "anthropics";
     repo = "skills";
-    rev = "f6656c1256d5a8adfa37db9110046ef20bac644c";
-    hash = "sha256-5/0f5AnGWX3oM+M9Xm/zSmooz11+S1YRdFPmAX+DXi0=";
+    rev = "0a64e398ec6bb34a494f0c347e8ccae53a862f8e";
+    hash = "sha256-0ZtHTJVHeW8jIprKgCo/yU2ZI2cZxUqD3Riet3UWdt8=";
   };
 
   # https://github.com/mattpocock/skills — "Skills For Real Engineers"
   matt-skills = pkgs.fetchFromGitHub {
     owner = "mattpocock";
     repo = "skills";
-    rev = "8b78b531ab965735c5dc74f6f7a219e1e37326df";
-    hash = "sha256-jsXcMkhu15MxR0zXnLLJeni0q0Aew2UxUSojl6zmOvg=";
+    rev = "0ab1b63a410a03d3627979a109c8695de27af954";
+    hash = "sha256-Zg64vWsmtVk7WCH/f+bifju+L8yHeAwYbDNh6Ah43V0=";
   };
 in
 {

--- a/packages/catppuccin-yazi-flavor/default.nix
+++ b/packages/catppuccin-yazi-flavor/default.nix
@@ -9,13 +9,13 @@
 
 stdenvNoCC.mkDerivation {
   pname = "catppuccin-yazi";
-  version = "0-unstable-2026-06-13";
+  version = "0-unstable-2026-08-20";
 
   src = fetchFromGitHub {
     owner = "catppuccin";
     repo = "yazi";
-    rev = "baaf5d1c9427b836fbefd126aa855f9eab7a9d0d";
-    hash = "sha256-L6SApM07CSQk0znEsFP8WaxW+ZHcindXo612r1XcwIg=";
+    rev = "d62802be39210ea10e54b3e3b09735c6cb9e57c1";
+    hash = "sha256-bwzEO8exoBwa19q+jnYjHkaamGl2mhfukIEhDfUCRGI=";
   };
 
   nativeBuildInputs = [

--- a/packages/gstack/default.nix
+++ b/packages/gstack/default.nix
@@ -58,8 +58,8 @@ stdenv.mkDerivation (finalAttrs: {
     outputHash =
       {
         x86_64-linux = "sha256-TnS4+cDirVE8orRzh2/iWajS/kTjOoqgWPVnfTO4tpw=";
-        aarch64-linux = "sha256-r1+VP34SiAVBm/l1QvIr238ha5Su3THFA9aAn6cpZ/E=";
-        aarch64-darwin = "sha256-wC/aKWuEnShhAKK0MXXtS5z8zZLYg2Q5rPJHuAk2OsM=";
+        aarch64-linux = "sha256-WFT0RFJ5Xbh0myRY8O2Vkkzuoqwe4HgyA+CLZ9uehm4=";
+        aarch64-darwin = "sha256-F/tSMTwnlvL7dh/kO7vmtT30iCszLvUDzH+07mZi0Zo=";
       }
       .${stdenv.hostPlatform.system}
         or (throw "gstack node_modules hash not available for ${stdenv.hostPlatform.system}");

--- a/packages/gstack/default.nix
+++ b/packages/gstack/default.nix
@@ -15,13 +15,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gstack";
-  version = "0-unstable-2026-08-12";
+  version = "0-unstable-2026-08-20";
 
   src = fetchFromGitHub {
     owner = "garrytan";
     repo = "gstack";
-    rev = "d078622b73539fc1a7a27e709861e9b6b058ae98";
-    hash = "sha256-28fkbcY/VFAq9W9LF8Bpq2SqHZnncKOdRhmuRZh5AdU=";
+    rev = "51932eceef9cf45ad5fbf2b19e15615f96df2872";
+    hash = "sha256-fIk3cGjeNDTxxQGr75Y2cQHIdGdhfNCZsttWPx53HN4=";
   };
 
   # Fixed-output derivation for node_modules (network access allowed in sandbox)
@@ -57,7 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     outputHash =
       {
-        x86_64-linux = "sha256-4ydW9f/svvMEMTZN1lk4C5uoUxxxDyFdKTSu8c8bxgo=";
+        x86_64-linux = "sha256-TnS4+cDirVE8orRzh2/iWajS/kTjOoqgWPVnfTO4tpw=";
         aarch64-linux = "sha256-r1+VP34SiAVBm/l1QvIr238ha5Su3THFA9aAn6cpZ/E=";
         aarch64-darwin = "sha256-wC/aKWuEnShhAKK0MXXtS5z8zZLYg2Q5rPJHuAk2OsM=";
       }


### PR DESCRIPTION
## 升级内容

| 依赖 | 旧 rev/tag | 新 rev/tag |
|---|---|---|
| catppuccin/yazi | baaf5d1c | d62802be |
| garrytan/gstack | d078622b | 51932ece |
| anthropics/skills | f6656c12 | 0a64e398 |
| mattpocock/skills | 8b78b531 | 0ab1b63a |

- 所有 fetchFromGitHub hash 已用 `nix-prefetch-url --unpack` 重新计算并转换为 SRI。
- 引用的路径已验证存在（catppuccin-yazi flavor、anthropics skill-creator、mattpocock grill-me/grilling）。
- gstack bun.lock 有变化：x86_64-linux node_modules hash 已通过本地 `nix build` 权威计算；aarch64-linux / aarch64-darwin hash 暂保留旧值，等待 CI 报错后从日志提取（PR checker 会自动修复）。